### PR TITLE
Namespace und so

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Vollständige Video-Management-Lösung für REDAXO CMS – Konvertierung, Trimmi
 - **Fallback-Placeholder** bei FFmpeg-Problemen
 
 ### 🆕 PHP-API für Entwickler
-- **Module-Integration** mit `rex_ffmpeg_video_info` Klasse
+- **Module-Integration** mit `VideoInfo` Klasse (`FriendsOfRedaxo\FFmpeg\VideoInfo`)
 - **Performance-optimierte Methoden** für häufige Abfragen
 - **Template-Integration** für Video-Galerien und responsive Player
 - **Optimierungs-Checks** für automatische Qualitätsbewertung
@@ -77,9 +77,11 @@ Vollständige Video-Management-Lösung für REDAXO CMS – Konvertierung, Trimmi
 
 ```php
 <?php
+use FriendsOfRedaxo\FFmpeg;
+
 // Video-Informationen in Modulen abrufen
 $videoFile = 'REX_MEDIA[1]';
-$info = rex_ffmpeg_video_info::getBasicInfo($videoFile);
+$info = VideoInfo::getBasicInfo($videoFile);
 
 if ($info) {
     echo '<div class="video-info">';
@@ -97,14 +99,16 @@ if ($info) {
 
 ```php
 <?php
+use FriendsOfRedaxo\FFmpeg;
+
 $videoFile = 'REX_MEDIA[1]';
 
 // Nur Dauer ermitteln (performance-optimiert)
-$duration = rex_ffmpeg_video_info::getDuration($videoFile);
+$duration = VideoInfo::getDuration($videoFile);
 echo 'Dauer: ' . $duration . ' Sekunden';
 
 // Nur Seitenverhältnis
-$ratio = rex_ffmpeg_video_info::getAspectRatio($videoFile);
+$ratio = VideoInfo::getAspectRatio($videoFile);
 echo 'Format: ' . $ratio;
 ?>
 ```
@@ -113,8 +117,10 @@ echo 'Format: ' . $ratio;
 
 ```php
 <?php
+use FriendsOfRedaxo\FFmpeg;
+
 $videoFile = 'REX_MEDIA[1]';
-$status = rex_ffmpeg_video_info::getOptimizationStatus($videoFile);
+$status = VideoInfo::getOptimizationStatus($videoFile);
 
 if ($status['optimized']) {
     echo '<span class="badge badge-success">Web-optimiert</span>';
@@ -133,8 +139,10 @@ echo '<p>Score: ' . $status['score'] . '/100</p>';
 
 ```php
 <?php
+use FriendsOfRedaxo\FFmpeg;
+
 $videoFile = 'REX_MEDIA[1]';
-$info = rex_ffmpeg_video_info::getBasicInfo($videoFile);
+$info = VideoInfo::getBasicInfo($videoFile);
 
 if ($info) {
     // CSS-Klasse basierend auf Seitenverhältnis
@@ -180,6 +188,8 @@ echo '</video>';
 
 ```php
 <?php
+use FriendsOfRedaxo\FFmpeg;
+
 // Video-Liste aus dem Medienpool
 $sql = rex_sql::factory();
 $videos = $sql->getArray('SELECT filename FROM rex_media WHERE filetype LIKE "video/%"');
@@ -187,7 +197,7 @@ $videos = $sql->getArray('SELECT filename FROM rex_media WHERE filetype LIKE "vi
 echo '<div class="video-gallery">';
 foreach ($videos as $video) {
     $filename = $video['filename'];
-    $info = rex_ffmpeg_video_info::getBasicInfo($filename);
+    $info = VideoInfo::getBasicInfo($filename);
     
     // WebP-Thumbnail für bessere Performance
     $thumbnail = rex_media_manager::getUrl('video_webp_thumb', $filename);

--- a/boot.php
+++ b/boot.php
@@ -1,10 +1,17 @@
 <?php
 
 // Media Manager Effekte für Videos registrieren
+
+use FriendsOfRedaxo\FFmpeg\Api\Converter;
+
 if (rex_addon::get('media_manager')->isAvailable()) {
     rex_media_manager::addEffect('rex_effect_video_to_webp');
     rex_media_manager::addEffect('rex_effect_video_to_preview');
 }
+
+// Converter-API bereitstellen
+rex_api_function::register('ffmpeg_convert', Converter::class);
+
 
 if (rex::isBackend() && rex::getUser()) {
     // Add JavaScript to ffmpeg page

--- a/lib/Api/Converter.php
+++ b/lib/Api/Converter.php
@@ -1,5 +1,20 @@
 <?php
-class rex_api_ffmpeg_converter extends rex_api_function
+namespace FriendsOfRedaxo\FFmpeg\Api;
+
+use Exception;
+use rex;
+use rex_addon;
+use rex_api_exception;
+use rex_api_function;
+use rex_backend_login;
+use rex_file;
+use rex_formatter;
+use rex_logger;
+use rex_path;
+use rex_response;
+use rex_sql;
+
+class Converter extends rex_api_function
 {
     protected $published = true;
     
@@ -480,7 +495,7 @@ class rex_api_ffmpeg_converter extends rex_api_function
         return ['progress' => $progress, 'log' => $getContent, 'status' => 'converting'];
     }
 
-    // In ffmpeg_api.php, die handleDone-Methode verbessern:
+    // TODO: Im API Converter (ex ffmpeg_api.php), die handleDone-Methode verbessern
 
 protected function handleDone()
 {

--- a/lib/VideoInfo.php
+++ b/lib/VideoInfo.php
@@ -8,7 +8,15 @@
  * @package redaxo\ffmpeg
  * @author KLXM Crossmedia GmbH
  */
-class rex_ffmpeg_video_info
+namespace FriendsOfRedaxo\FFmpeg;
+
+use rex_formatter;
+use rex_media;
+use rex_media_manager;
+use rex_path;
+use rex_url;
+
+class VideoInfo
 {
     /**
      * Video-Informationen für eine Datei ermitteln


### PR DESCRIPTION
Als Vorschlag: Umstellung auf den Namespace `FriendsOfRedaxo\FFmpeg`.

Die Schreibweise `FFmpeg` ist vom Repo-Namen des FFMpeg abgeschaut.

- aus `rex_ffmpeg_video_info` wird  `FriendsOfRedaxo\FFmpeg\VideoInfo`
- aus `rex_api_ffmpeg_converter` wird `FriendsOfRedaxo\FFmpeg\Api\Converter`
- `Converter::class` wird in der boot.php als  Api `ffmpeg_converter` registriert.
- In der Readme sind die Code-Beispiele auf Namespace umgestellt

Nicht angepackt:
- Die MM-Effekte; da sie im Namespace nicht funktionieren.
- Versionshinweis in der package.yml
- Einführen eines Changelog
- Auflösen diverses "deprecated"-Meldungen Core- und MediaPool-Methoden betreffend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new API endpoint for video conversion.

* **Documentation**
  * Updated all documentation and example code to reference the new class names and namespaces for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->