### PR TITLE
Add translations and ffmpeg config for media pool categories

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -72,6 +72,10 @@ config_command_help = Das auszuführende FFmpeg-Kommando. Platzhalter: INPUT, OU
 config_preview_label = Vorschau des effektiven FFmpeg-Kommandos
 config_preset_priority = Priorität: Preset (außer preset=custom) > Kommando-Feld
 ffmpeg_execute = Video konvertieren
+mediapool_category_id = Kategorie-ID für konvertierte Videos (Standard: 0 für "Keine Kategorie")
+mediapool_category_empty = Keine Kategorie
+mediapool_category = Medienpool-Kategorie
+mediapool_category_description = Kategorie im Medienpool, in der die konvertierten Videos abgelegt werden sollen. Standard ist "Keine Kategorie" (ID 0).
 
 # Video-Trimmer
 ffmpeg_trimmer_select_video = Video zum Schneiden auswählen

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -73,6 +73,10 @@ config_command_help = The actual FFmpeg command executed. Placeholders: INPUT, O
 config_preview_label = Effective FFmpeg command preview
 config_preset_priority = Priority: preset (unless preset=custom) > command field
 ffmpeg_execute = Convert video
+mediapool_category_id = Category ID for converted videos (default: 0 for "No category")
+mediapool_category_empty = No category
+mediapool_category = Media pool category
+mediapool_category_description = Choose the category in which the converted videos should be stored. Default is "No category" (ID 0).
 
 # Video Trimmer
 ffmpeg_trimmer_select_video = Select video to cut

--- a/lib/Api/Converter.php
+++ b/lib/Api/Converter.php
@@ -757,7 +757,7 @@ class Converter extends rex_api_function
                 'name' => pathinfo($outputFile, PATHINFO_BASENAME),
                 'path' => $outputFile,
             ],
-            'category_id' => 0,
+            'category_id' =>  rex_addon::get('ffmpeg')->getConfig('mediapool_category_id', 0),
             'title' => '',
         ];
         try {

--- a/lib/Api/Converter.php
+++ b/lib/Api/Converter.php
@@ -757,7 +757,7 @@ class Converter extends rex_api_function
                 'name' => pathinfo($outputFile, PATHINFO_BASENAME),
                 'path' => $outputFile,
             ],
-            'category_id' =>  rex_addon::get('ffmpeg')->getConfig('mediapool_category_id', 0),
+            'category_id' => (int) rex_addon::get('ffmpeg')->getConfig('mediapool_category_id', 0),
             'title' => '',
         ];
         try {

--- a/pages/mediapool.ffmpeg.config.php
+++ b/pages/mediapool.ffmpeg.config.php
@@ -25,6 +25,7 @@ if (rex_post('formsubmit', 'string') == '1' && !$csrfToken->isValid()) {
         ['command', 'string'],
         ['delete', 'string'],
         ['preset', 'string'],
+        ['mediapool_category_id', 'int'],
     ]);
 
     // Keep the same preset mapping as the top-level one — always include the ffmpeg prefix
@@ -136,6 +137,33 @@ $formElements[] = $n;
 $fragment = new rex_fragment();
 $fragment->setVar('elements', $formElements, false);
 $content .= $fragment->parse('core/form/checkbox.php');
+
+// ── Mediapool-Kategorie ───────────────────────────────────────────────────
+$formElements = [];
+$n = [];
+$n['label'] = '<label for="ffmpeg-config-mediapool-category">' . $this->i18n('mediapool_category') . '</label>';
+
+$select = new rex_select();
+$select->setId('ffmpeg-config-mediapool-category');
+$select->setAttribute('class', 'form-control');
+$select->setName('config[mediapool_category_id]');
+$select->addOption($this->i18n('mediapool_category_empty'), 0);
+
+$sql = rex_sql::factory();
+$sql->setQuery('SELECT id, name FROM rex_media_category ORDER BY name');
+foreach ($sql as $row) {
+    $select->addOption($row->getValue('name'), $row->getValue('id'));
+}
+
+$select->setSelected((int) $this->getConfig('mediapool_category_id', 0));
+$n['field'] = $select->get();
+$formElements[] = $n;
+
+$fragment = new rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$content .= $fragment->parse('core/form/container.php');
+
+$content .= '<p class="text-muted">' . $this->i18n('mediapool_category_description') . '</p>';
 
 /*
  *

--- a/pages/mediapool.ffmpeg.config.php
+++ b/pages/mediapool.ffmpeg.config.php
@@ -150,7 +150,8 @@ $select->setName('config[mediapool_category_id]');
 $select->addOption($this->i18n('mediapool_category_empty'), 0);
 
 $sql = rex_sql::factory();
-$sql->setQuery('SELECT id, name FROM rex_media_category ORDER BY name');
+$table = rex::getTable('media_category');
+$sql->setQuery('SELECT id, name FROM ' . $table . ' ORDER BY name');
 foreach ($sql as $row) {
     $select->addOption($row->getValue('name'), $row->getValue('id'));
 }


### PR DESCRIPTION
Es kann ein Medienpool-Ordner als Output für konvertierte Videos definiert werden.